### PR TITLE
Update JavaSparkContextVarargsWorkaround.java

### DIFF
--- a/core/src/main/java/org/apache/spark/api/java/JavaSparkContextVarargsWorkaround.java
+++ b/core/src/main/java/org/apache/spark/api/java/JavaSparkContextVarargsWorkaround.java
@@ -50,7 +50,7 @@ abstract class JavaSparkContextVarargsWorkaround {
     return union(rdds[0], rest);
   }
   
-  public static final List<T> populateRDDList(T rdds) {
+  private static final List<T> populateRDDList(T[] rdds) {
     List<T> rest = new ArrayList<>(rdds.length - 1);
     for (int i = 1; i < rdds.length; i++) {
       rest.add(rdds[i]);


### PR DESCRIPTION
Making methid private and T[] as an array.